### PR TITLE
test(syscalls): add failing test case for write syscall

### DIFF
--- a/syscalls/src/sys_write.rs
+++ b/syscalls/src/sys_write.rs
@@ -353,4 +353,9 @@ mod tests {
 
         assert_eq!(poll2, Poll::Ready(Ok(buf.len() as isize)));
     }
+
+    #[test]
+    fn foo() {
+        assert_ne!(0, 0);
+    }
 }


### PR DESCRIPTION
- Add new test function 'foo' in sys_write.rs
- Intentionally assert a failure (0 != 0)
- This test will consistently fail, demonstrating a bug or incorrect behavior